### PR TITLE
Smaller image in unit test to fit into 4GB GPU memory

### DIFF
--- a/tests/algorithm_test.cu
+++ b/tests/algorithm_test.cu
@@ -223,13 +223,13 @@ BOLT_AUTO_TEST_CASE(ForeachPositionOverBigView) {
 }
 
 BOLT_AUTO_TEST_CASE(DimReduceOverStackOfSmallImages) {
-	DeviceImage<int, 3> device_image(32, 32, 1 << 20);
+	DeviceImage<int, 3> device_image(32, 32, 1 << 19);
 	DeviceImage<int, 2> target_image(32, 32);
 
 	auto source_view = makeConstantImageView(1, device_image.size());
 	copy(source_view, device_image.view());
 	dimensionReduce(device_image.view(), target_image.view(), DimensionValue<2>{}, 0, thrust::plus<int>());
-	BOOST_CHECK_EQUAL(sumSquareDifferences(makeConstantImageView(1 << 20, target_image.size()), target_image.view(), 0), 0);
+	BOOST_CHECK_EQUAL(sumSquareDifferences(makeConstantImageView(1 << 19, target_image.size()), target_image.view(), 0), 0);
 }
 
 BOLT_AUTO_TEST_CASE(HostForEachPosition) {


### PR DESCRIPTION
Lowered the image size from 4 to 2 GB to make ti work on the 4GB 1050 Ti.

The interpolated_view_test is failing as well but there is already TODO and it doesn't seem straight forward so I didn't try to fix it.