### PR TITLE
change transform locator to use output view size

### DIFF
--- a/boltview/for_each.h
+++ b/boltview/for_each.h
@@ -118,7 +118,7 @@ forEach(TView view, TFunctor functor, TPolicy policy, cudaStream_t cuda_stream =
 		return;
 	}
 	detail::ForEachFunctor<TFunctor, TView, TPolicy> lambda{functor};
-	detail::IterateImplementation<TView::kIsDeviceView, detail::ViewIndexingLocator<TView>>::run(view, lambda, policy, cuda_stream);
+	detail::IterateImplementation<TView::kIsDeviceView, detail::ViewIndexingLocator<TView>>::run(view, view, lambda, policy, cuda_stream);
 }
 
 /// Apply functor on each element in passed view
@@ -173,7 +173,7 @@ forEachPosition(TView view, TFunctor functor, TPolicy policy, cudaStream_t cuda_
 		return;
 	}
 	detail::ForEachPositionFunctor<TFunctor, TView, TPolicy> lambda (functor);
-	detail::IterateImplementation<TView::kIsDeviceView, detail::ViewIndexingLocator<TView>>::run(view, lambda, policy, cuda_stream);
+	detail::IterateImplementation<TView::kIsDeviceView, detail::ViewIndexingLocator<TView>>::run(view, view, lambda, policy, cuda_stream);
 }
 
 /// Apply functor on each element in passed view together with the element's coordinate.
@@ -248,7 +248,7 @@ forEachLocator(TView view, TFunctor functor, TPolicy policy, cudaStream_t cuda_s
         static_assert(!std::is_reference<typename TView::AccessType>::value || std::is_const<typename TView::AccessType>::value,
 		"ForeachLocator should be used on constant view. If you try modifying the view you will get race conditions.");
 	detail::ForEachLocatorFunctor<TFunctor, TView, TPolicy> lambda{functor};
-	detail::IterateImplementation<TView::kIsDeviceView, detail::LocatorConstructor<TView, TPolicy::kPreloadToSharedMemory> >::run(view, lambda, policy, cuda_stream);
+	detail::IterateImplementation<TView::kIsDeviceView, detail::LocatorConstructor<TView, TPolicy::kPreloadToSharedMemory> >::run(view, view, lambda, policy, cuda_stream);
 }
 
 /// Applies an operation for each each element of the view.

--- a/boltview/transform.h
+++ b/boltview/transform.h
@@ -127,7 +127,7 @@ transform(TInView in_view, TOutView out_view, TFunctor functor, TPolicy policy, 
 		return;
 	}
 	detail::TransformFunctor<TFunctor, TInView, TOutView, TPolicy> lambda (functor, out_view);
-	detail::IterateImplementation<TInView::kIsDeviceView && TOutView::kIsDeviceView, detail::ViewIndexingLocator<TInView>>::run(in_view, lambda, policy, cuda_stream);
+	detail::IterateImplementation<TInView::kIsDeviceView && TOutView::kIsDeviceView, detail::ViewIndexingLocator<TInView>>::run(in_view, out_view, lambda, policy, cuda_stream);
 }
 
 
@@ -200,7 +200,7 @@ transformPosition(TInView in_view, TOutView out_view, TFunctor functor, TPolicy 
 		return;
 	}
 
-	detail::IterateImplementation<TInView::kIsDeviceView && TOutView::kIsDeviceView, detail::ViewIndexingLocator<TInView>>::run(in_view, lambda, policy, cuda_stream);
+	detail::IterateImplementation<TInView::kIsDeviceView && TOutView::kIsDeviceView, detail::ViewIndexingLocator<TInView>>::run(in_view, out_view, lambda, policy, cuda_stream);
 }
 
 /// Applies an operation on each element of the input view and stores the result in the output view, Functor obtains also element index as an argument together with element value.
@@ -305,7 +305,7 @@ transformLocator(TInView in_view, TOutView out_view, TFunctor functor, TPolicy p
 	}
 
 	detail::TransformLocatorFunctor<TFunctor, TInView, TOutView, TPolicy> lambda (functor, out_view);
-	detail::IterateImplementation<TInView::kIsDeviceView && TOutView::kIsDeviceView, detail::LocatorConstructor<TInView, TPolicy::kPreloadToSharedMemory> >::run(in_view, lambda, policy, cuda_stream);
+	detail::IterateImplementation<TInView::kIsDeviceView && TOutView::kIsDeviceView, detail::LocatorConstructor<TInView, TPolicy::kPreloadToSharedMemory> >::run(in_view, out_view, lambda, policy, cuda_stream);
 }
 
 /// Applies an operation for each each element of the output view.


### PR DESCRIPTION
mango uses transform locator to fill output view that is larger with contents of a smaller input view. In ecip, the kernel was run according to output view size.